### PR TITLE
Only read until crlf

### DIFF
--- a/whisky/src/main.rs
+++ b/whisky/src/main.rs
@@ -48,7 +48,6 @@ impl Whisky {
                     let handlers = self.handlers.clone();
                     thread::spawn(move || {
                         handle_client(stream, handlers);
-                        // progressive_handle(stream, handlers)
                     });
                 }
                 Err(e) => panic!("an error has occured {}", e)

--- a/whisky/src/main.rs
+++ b/whisky/src/main.rs
@@ -123,15 +123,13 @@ fn progressive_handle(mut stream: TcpStream, handlers: HashMap<String, WhiskyHan
     let mut found_CRLF = 0;
     // goes "even" "odd" depending on wether CR was the last found true (odd) or LF was found false (even)
     let mut last_found_CR = false;
+    let mut header = Vec::new();
         
     for res in stream.bytes() {
-        println!("last_found_CR {}", last_found_CR);
+        // println!("last_found_CR {}", last_found_CR);
         match res {
             Ok(b) => {
-                if found_CRLF == 2 {
-                    println!("End of Header");
-                    break
-                }
+                header.push(b);
                 if b == 13 {
                     last_found_CR = true;
                     println!("Found CR")
@@ -142,12 +140,23 @@ fn progressive_handle(mut stream: TcpStream, handlers: HashMap<String, WhiskyHan
                     last_found_CR = false;
                     println!("Found LF")
                 } else {
-                    println!("Have a bute {:?}", b)
+                    found_CRLF = 0;
+                    println!("Have a byte {:?}", b)
+                }
+                println!("found_CRLF {}", found_CRLF);
+                if found_CRLF == 2 {
+                    println!("End of Header");
+                    break
                 }
             }
             Err(e) => println!("There was an erro matchin on a byte: {}", e)
         }
     }
+    let string_request = match String::from_utf8(header){
+        Ok(sr) => sr,
+        Err(e) => { println!("The request is not in utf8: {}", e); String::from("")}
+    };
+    println!("The wholeResquest\n{:?}\nTHEEND", string_request)
 }
 
 fn handle_client(mut stream: TcpStream, handlers: HashMap<String, WhiskyHandler>) {

--- a/whisky/src/main.rs
+++ b/whisky/src/main.rs
@@ -119,31 +119,27 @@ impl Context {
     }
 }
 
-fn parse_header_real(mut stream: &TcpStream) -> String {
+fn parse_header(mut stream: &TcpStream) -> String {
     let mut found_CRLF = 0;
     // goes "even" "odd" depending on wether CR was the last found true (odd) or LF was found false (even)
     let mut last_found_CR = false;
     let mut header = Vec::new();
         
     for res in stream.bytes() {
-        // println!("last_found_CR {}", last_found_CR);
         match res {
             Ok(b) => {
                 header.push(b);
                 if b == 13 {
                     last_found_CR = true;
-                    println!("Found CR")
                 } else if b == 10 {
                     if last_found_CR {
                        found_CRLF += 1;
                     }
                     last_found_CR = false;
-                    println!("Found LF")
                 } else {
                     found_CRLF = 0;
                     println!("Have a byte {:?}", b)
                 }
-                println!("found_CRLF {}", found_CRLF);
                 if found_CRLF == 2 {
                     println!("End of Header");
                     break
@@ -156,30 +152,8 @@ fn parse_header_real(mut stream: &TcpStream) -> String {
         Ok(sr) => sr,
         Err(e) => { println!("The request is not in utf8: {}", e); String::from("")}
     };
-    println!("The wholeResquest\n{:?}\nTHEEND", string_header);
     string_header
 
-}
-
-fn parse_header(mut stream: &TcpStream) -> String {
-    stream.set_read_timeout(Some(Duration::from_millis(1))).unwrap();
-    let mut request = Vec::new();
-    match stream.read_to_end(&mut request) {
-        Ok(bytes_read) => println!("We have read {} bytes", bytes_read),
-        Err(e) => {
-            match e.kind() {
-                ErrorKind::WouldBlock => {
-                    // println!("would have blocked ");
-                },
-                _ => panic!("somhow a non byte came through: {}", e)
-            }
-        }
-    }
-    let string_request = match String::from_utf8(request){
-        Ok(sr) => sr,
-        Err(e) => { println!("The request is not in utf8: {}", e); String::from("")}
-    };
-    string_request
 }
 
 fn handle_client(mut stream: TcpStream, handlers: HashMap<String, WhiskyHandler>) {

--- a/whisky/src/main.rs
+++ b/whisky/src/main.rs
@@ -119,7 +119,7 @@ impl Context {
     }
 }
 
-fn progressive_handle(mut stream: TcpStream, handlers: HashMap<String, WhiskyHandler>) {
+fn parse_header_real(mut stream: &TcpStream) -> String {
     let mut found_CRLF = 0;
     // goes "even" "odd" depending on wether CR was the last found true (odd) or LF was found false (even)
     let mut last_found_CR = false;
@@ -156,10 +156,12 @@ fn progressive_handle(mut stream: TcpStream, handlers: HashMap<String, WhiskyHan
         Ok(sr) => sr,
         Err(e) => { println!("The request is not in utf8: {}", e); String::from("")}
     };
-    println!("The wholeResquest\n{:?}\nTHEEND", string_header)
+    println!("The wholeResquest\n{:?}\nTHEEND", string_header);
+    string_header
+
 }
 
-fn parse_header(mut stream: TcpStream) -> (String, TcpStream){
+fn parse_header(mut stream: &TcpStream) -> String {
     stream.set_read_timeout(Some(Duration::from_millis(1))).unwrap();
     let mut request = Vec::new();
     match stream.read_to_end(&mut request) {
@@ -177,12 +179,12 @@ fn parse_header(mut stream: TcpStream) -> (String, TcpStream){
         Ok(sr) => sr,
         Err(e) => { println!("The request is not in utf8: {}", e); String::from("")}
     };
-    (string_request, stream)
+    string_request
 }
 
 fn handle_client(mut stream: TcpStream, handlers: HashMap<String, WhiskyHandler>) {
     // println!("handling request");
-    let (string_request, stream) = parse_header(stream);
+    let string_request = parse_header(&stream);
 
 
     let context = Context::new(string_request, stream);


### PR DESCRIPTION
#Switch how we parse headers. We need to look for two 'CRLF' combinations. In order to know that the header field is finished.